### PR TITLE
Add GitHub Actions CI for Lean build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: leanprover/lean-action@v1
+      - run: lake build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to compile the Lean project on pushes and PRs

## Testing
- `lake build` *(fails: `lake` command not found)*